### PR TITLE
Use explicit bundle install instead of bundler-cache

### DIFF
--- a/.github/workflows/jekyll-cd.yml
+++ b/.github/workflows/jekyll-cd.yml
@@ -17,7 +17,9 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: 3.2
-          bundler-cache: true
+
+      - name: install dependencies
+        run: bundle install
 
       - name: jekyll build
         run: JEKYLL_ENV=production bundle exec jekyll build --destination _site


### PR DESCRIPTION
bundler-cache: true requires a Gemfile.lock to exist upfront. Using explicit bundle install allows dependencies to be resolved fresh without a pre-existing lockfile.